### PR TITLE
Change interval run text color to red

### DIFF
--- a/script.js
+++ b/script.js
@@ -468,7 +468,7 @@ function getActivityProperties(activityString) {
         case 'base': colorClass = 'activity-text-base'; break;
         case 'recovery': colorClass = 'activity-text-recovery'; break;
         case 'tempo': colorClass = 'activity-text-tempo'; break;
-        case 'interval': colorClass = 'activity-text-interval'; break;
+        case 'interval': colorClass = 'activity-text-interval-red'; break;
         case 'fartlek': colorClass = 'activity-text-fartlek'; break;
         case 'strides_hills': colorClass = 'activity-text-str-hills'; break;
         case 'rest': colorClass = 'activity-text-rest'; break;

--- a/style.css
+++ b/style.css
@@ -1017,6 +1017,7 @@ body.dark-mode #darkModeToggle:focus {
 .activity-text-base, .pace-text-base { color: var(--activity-text-base) !important; }
 .activity-text-tempo, .pace-text-tempo { color: var(--activity-text-tempo) !important; }
 .activity-text-interval, .activity-text-intervals, .pace-text-interval, .pace-text-intervals { color: var(--activity-text-interval) !important; }
+.activity-text-interval-red, .pace-text-interval-red { color: red !important; } /* New style for red interval text */
 .activity-text-fartlek, .pace-text-fartlek { color: var(--activity-text-fartlek) !important; }
 .activity-text-str, .activity-text-hills, .pace-text-str, .pace-text-hills { color: var(--activity-text-str-hills) !important; }
 .activity-text-rest, .pace-text-rest { color: var(--activity-text-rest) !important; }


### PR DESCRIPTION
- Modified `getActivityProperties` in `script.js` to assign a new CSS class `activity-text-interval-red` for interval activities.
- Added a CSS rule in `style.css` to style `activity-text-interval-red` with red color.