### PR TITLE
I've hidden the zone text in the today card when the pace is displayed.

### DIFF
--- a/script.js
+++ b/script.js
@@ -1102,6 +1102,11 @@ function _buildTodaysActivityHtml(todaysActivity, activityProps, paceString) {
     if (todaysActivity) {
         let activityTextForDisplay = todaysActivity.activity.replace(/^[^:]+:\s*/, '').trim();
 
+        // If a pace is being displayed, remove the detailed zone text (e.g., "Z1 (High)") from the main activity description.
+        if (paceString) {
+            activityTextForDisplay = activityTextForDisplay.replace(/\s*Z[1-5]\s*\((Low|Average|High)\)/gi, '').trim();
+        }
+
         // If the description is empty after stripping prefix (e.g. "Easy:"), use a fallback display name.
         if (!activityTextForDisplay && todaysActivity.activity.includes(':')) {
             const type = activityProps.type;


### PR DESCRIPTION
I modified the `_buildTodaysActivityHtml` function to remove zone-specific text (e.g., 'Z1 (High)') from the main activity description in the 'Today's Training' card when a corresponding pace for that zone is also being displayed.

This change enhances UI clarity by avoiding redundant information. The detailed pace table and its highlighting logic remain unaffected.